### PR TITLE
ADDED limit:-1 to allow all pages rather than default 100

### DIFF
--- a/services/Sitemap.js
+++ b/services/Sitemap.js
@@ -45,7 +45,7 @@ module.exports = {
         name: 'sitemap',
       })
       .get({ key: 'settings' });
-  
+
     if (!config) {
       config = await createDefaultConfig('');
     }
@@ -69,7 +69,7 @@ module.exports = {
           uidFieldName = i;
         }
       })
-      
+
       if (uidFieldName) {
         contentTypes[contentType.modelName] = {
           uidField: uidFieldName,
@@ -88,7 +88,7 @@ module.exports = {
 
   getUrls: (contentType, pages, config) => {
     let urls = [];
-      
+
     pages.map((e) => {
       Object.entries(e).map(([i, e]) => {
         if (i === config.contentTypes[contentType].uidField) {
@@ -108,7 +108,7 @@ module.exports = {
       let modelName;
       const contentTypeByName = Object.values(strapi.contentTypes)
         .find(strapiContentType => strapiContentType.info.name === contentType);
-      
+
       // Backward compatibility for issue https://github.com/boazpoolman/strapi-plugin-sitemap/issues/4
       if (contentTypeByName) {
         modelName = contentTypeByName.modelName;
@@ -116,7 +116,7 @@ module.exports = {
         modelName = contentType;
       }
 
-      const pages = await strapi.query(modelName).find();
+      const pages = await strapi.query(modelName).find({_limit: -1});
       const urls = await module.exports.getUrls(contentType, pages, config);
 
       urls.map((url) => {
@@ -141,7 +141,7 @@ module.exports = {
     // Add a homepage when none is present
     if (config.includeHomepage) {
       const hasHomePage = !isEmpty(sitemapEntries.filter(entry => entry.url === ''));
-  
+
       if (!hasHomePage) {
         sitemapEntries.push({
           url: '/',


### PR DESCRIPTION
With default `strapi.query(modelName).find();`, strapi only returns the first 100 items, which isn't great if you have more than 100 pages in any content type. Adding `{_limit: -1}` returns all items in the content type.