### PR TITLE
Add ability to use nested fields from relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ Fields can be injected in the pattern by escaping them with `[]`.
 
 Also relations can be queried in the pattern like so: `[relation.fieldname]`.
 
+The following field types are by default allowed in a pattern:
+
+- `id`
+- `uid`
+
 *Allowed field types can be altered with the `allowedFields` config. Read more about it below.*
 
 ## 🌍 Multilingual

--- a/README.md
+++ b/README.md
@@ -97,15 +97,12 @@ Custom URLs will get the following XML attributes:
 To create dynamic URLs this plugin uses **URL patterns**. A URL pattern is used when adding URL bundles to the sitemap and has the following format:
 
 ```
-/pages/[my-uid-field]
+/pages/[category.slug]/[my-uid-field]
 ```
 
 Fields can be injected in the pattern by escaping them with `[]`.
 
-The following field types are by default allowed in a pattern:
-
-- id
-- uid
+Also relations can be queried in the pattern like so: `[relation.fieldname]`.
 
 *Allowed field types can be altered with the `allowedFields` config. Read more about it below.*
 

--- a/server/services/__tests__/pattern.test.js
+++ b/server/services/__tests__/pattern.test.js
@@ -6,24 +6,27 @@ const patternService = require('../pattern');
 describe('Pattern service', () => {
   describe('Get fields from pattern', () => {
     test('Should return an array of fieldnames extracted from a pattern', () => {
-      const pattern = '/en/[category]/[slug]';
+      const pattern = '/en/[category]/[slug]/[relation.id]';
 
       const result = patternService().getFieldsFromPattern(pattern);
 
-      expect(result).toEqual(['category', 'slug']);
+      expect(result).toEqual(['category', 'slug', 'relation.id']);
     });
   });
   describe('Resolve pattern', () => {
     test('Resolve valid pattern', async () => {
-      const pattern = '/en/[category]/[slug]';
+      const pattern = '/en/[category]/[slug]/[relation.url]';
       const entity = {
         category: 'category-a',
         slug: 'my-page-slug',
+        relation: {
+          url: 'relation-url',
+        },
       };
 
       const result = await patternService().resolvePattern(pattern, entity);
 
-      expect(result).toMatch('/en/category-a/my-page-slug');
+      expect(result).toMatch('/en/category-a/my-page-slug/relation-url');
     });
 
     test('Resolve pattern with missing field', async () => {

--- a/server/services/__tests__/pattern.test.js
+++ b/server/services/__tests__/pattern.test.js
@@ -55,17 +55,6 @@ describe('Pattern service', () => {
       expect(result).toContain('anotherRelation.id');
       expect(result).toContain('anotherRelation.slugField');
     });
-
-    test('Should return only the id as allowed', () => {
-      const allowedFields = ['id', 'uid'];
-      const contentType = {
-        attributes: {},
-      };
-
-      const result = patternService().getAllowedFields(contentType, allowedFields);
-
-      expect(result).toEqual(['id']);
-    });
   });
   describe('Get fields from pattern', () => {
     test('Should return an array of fieldnames extracted from a pattern', () => {

--- a/server/services/__tests__/pattern.test.js
+++ b/server/services/__tests__/pattern.test.js
@@ -3,7 +3,70 @@
 
 const patternService = require('../pattern');
 
+global.strapi = {
+  contentTypes: {
+    'another-test-relation:target:api': {
+      attributes: {
+        slugField: {
+          type: 'uid',
+        },
+        textField: {
+          type: 'text',
+        },
+      },
+    },
+  },
+};
+
 describe('Pattern service', () => {
+  describe('Get allowed fields for a content type', () => {
+    test('Should return the right fields', () => {
+      const allowedFields = ['id', 'uid'];
+      const contentType = {
+        attributes: {
+          urlField: {
+            type: 'uid',
+          },
+          textField: {
+            type: 'text',
+          },
+          localizations: {
+            type: 'relation',
+            target: 'test:target:api',
+            relation: 'oneToOne',
+          },
+          relation: {
+            type: 'relation',
+            target: 'another-test:target:api',
+            relation: 'oneToMany',
+          },
+          anotherRelation: {
+            type: 'relation',
+            target: 'another-test-relation:target:api',
+            relation: 'oneToOne',
+          },
+        },
+      };
+
+      const result = patternService().getAllowedFields(contentType, allowedFields);
+
+      expect(result).toContain('id');
+      expect(result).toContain('urlField');
+      expect(result).toContain('anotherRelation.id');
+      expect(result).toContain('anotherRelation.slugField');
+    });
+
+    test('Should return only the id as allowed', () => {
+      const allowedFields = ['id', 'uid'];
+      const contentType = {
+        attributes: {},
+      };
+
+      const result = patternService().getAllowedFields(contentType, allowedFields);
+
+      expect(result).toEqual(['id']);
+    });
+  });
   describe('Get fields from pattern', () => {
     test('Should return an array of fieldnames extracted from a pattern', () => {
       const pattern = '/en/[category]/[slug]/[relation.id]';

--- a/server/services/__tests__/pattern.test.js
+++ b/server/services/__tests__/pattern.test.js
@@ -52,8 +52,10 @@ describe('Pattern service', () => {
 
       expect(result).toContain('id');
       expect(result).toContain('urlField');
+      expect(result).not.toContain('textField');
       expect(result).toContain('anotherRelation.id');
       expect(result).toContain('anotherRelation.slugField');
+      expect(result).not.toContain('anotherRelation.textField');
     });
   });
   describe('Get fields from pattern', () => {

--- a/server/services/core.js
+++ b/server/services/core.js
@@ -130,15 +130,15 @@ const createSitemapEntries = async () => {
   // Collection entries.
   await Promise.all(Object.keys(config.contentTypes).map(async (contentType) => {
     const excludeDrafts = config.excludeDrafts && strapi.contentTypes[contentType].options.draftAndPublish;
-    
+
     const populate = ['localizations'].concat(Object.keys(strapi.contentTypes[contentType].attributes).reduce((prev, current) => {
-      
-     
-      if(strapi.contentTypes[contentType].attributes[current].type == 'relation'){
-        prev.push(current)
+
+
+      if (strapi.contentTypes[contentType].attributes[current].type === 'relation') {
+        prev.push(current);
       }
-      return prev
-    }, []))
+      return prev;
+    }, []));
 
     const pages = await noLimit(strapi.query(contentType), {
       where: {
@@ -159,11 +159,11 @@ const createSitemapEntries = async () => {
         },
       },
       populate,
-      orderBy: 'id'
+      orderBy: 'id',
     });
     // Add formatted sitemap page data to the array.
     await Promise.all(pages.map(async (page) => {
-    
+
       const pageData = await getSitemapPageData(page, contentType, excludeDrafts);
       if (pageData) sitemapEntries.push(pageData);
     }));

--- a/server/services/core.js
+++ b/server/services/core.js
@@ -26,6 +26,13 @@ const getLanguageLinks = async (page, contentType, defaultURL, excludeDrafts) =>
   const links = [];
   links.push({ lang: page.locale, url: defaultURL });
 
+  const populate = ['localizations'].concat(Object.keys(strapi.contentTypes[contentType].attributes).reduce((prev, current) => {
+    if (strapi.contentTypes[contentType].attributes[current].type === 'relation') {
+      prev.push(current);
+    }
+    return prev;
+  }, []));
+
   await Promise.all(page.localizations.map(async (translation) => {
     const translationEntity = await strapi.query(contentType).findOne({
       where: {
@@ -46,8 +53,7 @@ const getLanguageLinks = async (page, contentType, defaultURL, excludeDrafts) =>
           $notNull: true,
         } : {},
       },
-      orderBy: 'id',
-      populate: ['localizations'],
+      populate,
     });
 
     if (!translationEntity) return null;
@@ -141,8 +147,6 @@ const createSitemapEntries = async () => {
     const excludeDrafts = config.excludeDrafts && strapi.contentTypes[contentType].options.draftAndPublish;
 
     const populate = ['localizations'].concat(Object.keys(strapi.contentTypes[contentType].attributes).reduce((prev, current) => {
-
-
       if (strapi.contentTypes[contentType].attributes[current].type === 'relation') {
         prev.push(current);
       }

--- a/server/services/core.js
+++ b/server/services/core.js
@@ -42,9 +42,9 @@ const getLanguageLinks = async (page, contentType, defaultURL, excludeDrafts) =>
           },
         ],
         id: translation.id,
-        published_at: excludeDrafts ? {
-          $notNull: true,
-        } : {},
+        publishedAt: {
+          $notNull: excludeDrafts,
+        },
       },
       orderBy: 'id',
       populate: ['localizations'],
@@ -69,8 +69,7 @@ const getLanguageLinks = async (page, contentType, defaultURL, excludeDrafts) =>
 
     const { pattern } = config.contentTypes[contentType]['languages'][locale];
     const translationUrl = await strapi.plugins.sitemap.services.pattern.resolvePattern(pattern, translationEntity);
-    let hostnameOverride = config.hostname_overrides[translationEntity.locale] || '';
-    hostnameOverride = hostnameOverride.replace(/\/+$/, "");
+    const hostnameOverride = config.hostname_overrides[translationEntity.locale]?.replace(/\/+$/, "") || '';
     links.push({
       lang: translationEntity.locale,
       url: `${hostnameOverride}${translationUrl}`,
@@ -107,23 +106,17 @@ const getSitemapPageData = async (page, contentType, excludeDrafts) => {
 
   const { pattern } = config.contentTypes[contentType]['languages'][locale];
   const path = await strapi.plugins.sitemap.services.pattern.resolvePattern(pattern, page);
-  let hostnameOverride = config.hostname_overrides[page.locale] || '';
-  hostnameOverride = hostnameOverride.replace(/\/+$/, "");
+
+  const hostnameOverride = config.hostname_overrides[page.locale]?.replace(/\/+$/, "") || '';
   const url = `${hostnameOverride}${path}`;
 
-  const pageData = {
+  return {
     lastmod: page.updatedAt,
     url: url,
     links: await getLanguageLinks(page, contentType, url, excludeDrafts),
     changefreq: config.contentTypes[contentType]['languages'][locale].changefreq || 'monthly',
     priority: parseFloat(config.contentTypes[contentType]['languages'][locale].priority) || 0.5,
   };
-
-  if (config.contentTypes[contentType]['languages'][locale].includeLastmod === false) {
-    delete pageData.lastmod;
-  }
-
-  return pageData;
 };
 
 /**
@@ -162,9 +155,9 @@ const createSitemapEntries = async () => {
             },
           },
         ],
-        published_at: excludeDrafts ? {
-          $notNull: true,
-        } : {},
+        published_at: {
+          $notNull: excludeDrafts,
+        },
       },
       populate,
       orderBy: 'id',

--- a/server/services/pattern.js
+++ b/server/services/pattern.js
@@ -26,6 +26,8 @@ const getAllowedFields = (contentType, allowedFields = []) => {
         && field.target
         && field.relation.endsWith('ToOne') // TODO: implement `ToMany` relations (#78).
         && fieldName !== 'localizations'
+        && fieldName !== 'createdBy'
+        && fieldName !== 'updatedBy'
       ) {
         const relation = strapi.contentTypes[field.target];
 

--- a/server/services/pattern.js
+++ b/server/services/pattern.js
@@ -10,12 +10,14 @@ const { logMessage } = require("../utils");
  * Get all field names allowed in the URL of a given content type.
  *
  * @param {string} contentType - The content type.
+ * @param {array} allowedFields - Override the allowed fields.
  *
- * @returns {string} The fields.
+ * @returns {string[]} The fields.
  */
-const getAllowedFields = async (contentType) => {
+const getAllowedFields = (contentType, allowedFields = []) => {
   const fields = [];
-  strapi.config.get('plugin.sitemap.allowedFields').map((fieldType) => {
+  const fieldTypes = allowedFields.length > 0 ? allowedFields : strapi.config.get('plugin.sitemap.allowedFields');
+  fieldTypes.map((fieldType) => {
     Object.entries(contentType.attributes).map(([fieldName, field]) => {
       if (field.type === fieldType && field.type !== 'relation') {
         fields.push(fieldName);
@@ -28,7 +30,7 @@ const getAllowedFields = async (contentType) => {
         const relation = strapi.contentTypes[field.target];
 
         if (
-          strapi.config.get('plugin.sitemap.allowedFields').includes('id')
+          fieldTypes.includes('id')
           && !fields.includes(`${fieldName}.id`)
         ) {
           fields.push(`${fieldName}.id`);
@@ -44,7 +46,7 @@ const getAllowedFields = async (contentType) => {
   });
 
   // Add id field manually because it is not on the attributes object of a content type.
-  if (strapi.config.get('plugin.sitemap.allowedFields').includes('id')) {
+  if (fieldTypes.includes('id')) {
     fields.push('id');
   }
 

--- a/server/services/pattern.js
+++ b/server/services/pattern.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 
 /**
  * Pattern service.
@@ -11,45 +11,44 @@
  *
  * @returns {string} The fields.
  */
-const getAllowedFields = async contentType => {
-  const fields = []
-  strapi.config.get('plugin.sitemap.allowedFields').map(fieldType => {
+const getAllowedFields = async (contentType) => {
+  const fields = [];
+  strapi.config.get('plugin.sitemap.allowedFields').map((fieldType) => {
     Object.entries(contentType.attributes).map(([fieldName, field]) => {
       if (field.type === fieldType) {
-        fields.push(fieldName)
+        fields.push(fieldName);
       }
       if (field.type === 'relation' && field.target) {
-        const relation = strapi.contentTypes[field.target]
-        Object.entries(relation.attributes).map(([fieldName, field]) => {
-          if (field.type === fieldType) {
-            fields.push(fieldName)
+        const relation = strapi.contentTypes[field.target];
+        Object.entries(relation.attributes).map(([subFieldName, subField]) => {
+          if (subField.type === fieldType) {
+            fields.push(subFieldName);
           }
-        })
+        });
       }
-    })
-  })
+    });
+  });
 
   // Add id field manually because it is not on the attributes object of a content type.
   if (strapi.config.get('plugin.sitemap.allowedFields').includes('id')) {
-    fields.push('id')
+    fields.push('id');
   }
 
-  return fields
-}
+  return fields;
+};
 
-const recursiveMatch = fields => {
-  let result = {}
-  for (let o of fields) {
-    let field = RegExp(/\[([\w\d\[\]]+)\]/g).exec(o)[1]
+const recursiveMatch = (fields) => {
+  return fields.reduce((result, o) => {
+    const field = RegExp(/\[([\w\d[\]]+)\]/g).exec(o)[1];
     if (RegExp(/\[.*\]/g).test(field)) {
-      let fieldName = RegExp(/[\w\d]+/g).exec(field)[0]
-      result[fieldName] = recursiveMatch(field.match(/\[([\w\d\[\]]+)\]/g))
+      const fieldName = RegExp(/[\w\d]+/g).exec(field)[0];
+      result[fieldName] = recursiveMatch(field.match(/\[([\w\d[\]]+)\]/g));
     } else {
-      result[field] = {}
+      result[field] = {};
     }
-  }
-  return result
-}
+    return result;
+  }, {});
+};
 
 /**
  * Get all fields from a pattern.
@@ -58,11 +57,11 @@ const recursiveMatch = fields => {
  *
  * @returns {array} The fields.\[([\w\d\[\]]+)\]
  */
-const getFieldsFromPattern = pattern => {
-  let fields = pattern.match(/\[([\w\d\[\]]+)\]/g) // Get all substrings between [] as array.
-  fields = recursiveMatch(fields) // Strip [] from string.
-  return fields
-}
+const getFieldsFromPattern = (pattern) => {
+  let fields = pattern.match(/\[([\w\d[\]]+)\]/g); // Get all substrings between [] as array.
+  fields = recursiveMatch(fields); // Strip [] from string.
+  return fields;
+};
 
 /**
  * Resolve a pattern string from pattern to path for a single entity.
@@ -74,31 +73,31 @@ const getFieldsFromPattern = pattern => {
  */
 
 const resolvePattern = async (pattern, entity) => {
-  const fields = getFieldsFromPattern(pattern)
+  const fields = getFieldsFromPattern(pattern);
 
-  Object.keys(fields).map(field => {
+  Object.keys(fields).map((field) => {
     if (!Object.keys(fields[field]).length) {
-      pattern = pattern.replace(`[${field}]`, entity[field] || '')
+      pattern = pattern.replace(`[${field}]`, entity[field] || '');
     } else {
-      const subField = Object.keys(fields[field])[0]
+      const subField = Object.keys(fields[field])[0];
       if (Array.isArray(entity[field]) && entity[field][0]) {
         pattern = pattern.replace(
           `[${field}[${subField}]]`,
-          entity[field][0][subField] || ''
-        )
+          entity[field][0][subField] || '',
+        );
       } else {
         pattern = pattern.replace(
           `[${field}[${subField}]]`,
-          entity[field][subField] || ''
-        )
+          entity[field][subField] || '',
+        );
       }
     }
-  })
+  });
 
-  pattern = pattern.replace(/([^:]\/)\/+/g, '$1') // Remove duplicate forward slashes.
-  pattern = pattern.startsWith('/') ? pattern : `/${pattern}` // Add a starting slash.
-  return pattern
-}
+  pattern = pattern.replace(/([^:]\/)\/+/g, '$1'); // Remove duplicate forward slashes.
+  pattern = pattern.startsWith('/') ? pattern : `/${pattern}`; // Add a starting slash.
+  return pattern;
+};
 
 /**
  * Validate if a pattern is correctly structured.
@@ -114,64 +113,64 @@ const validatePattern = async (pattern, allowedFieldNames) => {
   if (!pattern) {
     return {
       valid: false,
-      message: 'Pattern can not be empty'
-    }
+      message: 'Pattern can not be empty',
+    };
   }
 
-  const preCharCount = pattern.split('[').length - 1
-  const postCharount = pattern.split(']').length - 1
+  const preCharCount = pattern.split('[').length - 1;
+  const postCharount = pattern.split(']').length - 1;
 
   if (preCharCount < 1 || postCharount < 1) {
     return {
       valid: false,
-      message: 'Pattern should contain at least one field'
-    }
+      message: 'Pattern should contain at least one field',
+    };
   }
 
   if (preCharCount !== postCharount) {
     return {
       valid: false,
-      message: 'Fields in the pattern are not escaped correctly'
-    }
+      message: 'Fields in the pattern are not escaped correctly',
+    };
   }
 
-  let fieldsAreAllowed = true
-  const allowedFieldsRecursive = fields => {
-    Object.keys(fields).map(field => {
+  let fieldsAreAllowed = true;
+  const allowedFieldsRecursive = (fields) => {
+    Object.keys(fields).map((field) => {
       try {
         if (
-          Object.keys(fields[field]) &&
-          Object.keys(fields[field]).length > 0
+          Object.keys(fields[field])
+          && Object.keys(fields[field]).length > 0
         ) {
-          allowedFieldsRecursive(fields[field])
+          allowedFieldsRecursive(fields[field]);
         }
       } catch (e) {
-        console.log('Failed!')
-        console.log(e)
+        console.log('Failed!');
+        console.log(e);
       }
 
-      if (!allowedFieldNames.includes(field)) fieldsAreAllowed = false
-      return true
-    })
-  }
-  allowedFieldsRecursive(getFieldsFromPattern(pattern))
+      if (!allowedFieldNames.includes(field)) fieldsAreAllowed = false;
+      return true;
+    });
+  };
+  allowedFieldsRecursive(getFieldsFromPattern(pattern));
 
   if (!fieldsAreAllowed) {
     return {
       valid: false,
-      message: 'Pattern contains forbidden fields'
-    }
+      message: 'Pattern contains forbidden fields',
+    };
   }
 
   return {
     valid: true,
-    message: 'Valid pattern'
-  }
-}
+    message: 'Valid pattern',
+  };
+};
 
 module.exports = () => ({
   getAllowedFields,
   getFieldsFromPattern,
   resolvePattern,
-  validatePattern
-})
+  validatePattern,
+});


### PR DESCRIPTION


### What does it do?

I adjusted how the paths are parsed to allow for the use of relation fields. So with this PR, you can use a related contenttypes fields in the path. 

This PR only supports 1 level of depth when using relations. If the relation returns an array, the first result will be used. Would like to improve this in the future

### Why is it needed?

Currently, relational attributes aren't able to be used.

### How to test it?
If the content type is called company, with relations to employees:
/company/[employee[name]]/[post]

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
