### PR TITLE
feat: Automatically create a paginated sitemap index for large sitemaps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - **Auto-updating** (Uses lifecycle methods to keep the sitemap XML up-to-date)
 - **URL bundles** (Bundle URLs by type and add them to the sitemap XML)
 - **Dynamic paths** (Implements URL patterns in which you can inject dynamic fields)
+- **Sitemap indexes** (Paginated sitemap indexes for large URL sets)
 - **Exclude URLs** (Exclude specified URLs from the sitemap)
 - **Custom URLs** (URLs of pages which are not managed in Strapi)
 - **Styled with XSL** (Human readable XML styling)
@@ -184,6 +185,7 @@ module.exports = ({ env }) => ({
       autoGenerate: true,
       allowedFields: ['id', 'uid'],
       excludedTypes: [],
+      limit: 45000,
     },
   },
 });
@@ -223,6 +225,16 @@ All types in this array will not be shown as an option when selecting the type o
 ###### Key: `excludedTypes `
 
 > `required:` NO | `type:` array | `default:` `['admin::permission', 'admin::role', 'admin::api-token', 'plugin::i18n.locale', 'plugin::users-permissions.permission', 'plugin::users-permissions.role']`
+
+### Limit
+
+When creating large sitemaps (50.000+ URLs) you might want to split the sitemap in to chunks that you bring together in a sitemap index.
+
+The limit is there to specify the maximum amount of URL a single sitemap may hold. If you try to add more URLs to a single sitemap.xml it will automatically be split up in to chunks which are brought together in a single sitemap index.
+
+###### Key: `limit `
+
+> `required:` NO | `type:` int | `default:` 45000
 
 ## 🤝 Contributing
 

--- a/admin/src/components/Info/index.js
+++ b/admin/src/components/Info/index.js
@@ -86,14 +86,25 @@ const Info = () => {
               {`${month}/${day}/${year} - ${time}`}
             </Typography>
           </div>
-          <div style={{ marginBottom: '15px' }}>
-            <Typography variant="omega">
-              {formatMessage({ id: 'sitemap.Info.SitemapIsPresent.AmountOfURLs', defaultMessage: 'Amount of URLs:' })}
-            </Typography>
-            <Typography variant="omega" fontWeight="bold" style={{ marginLeft: '5px' }}>
-              {sitemapInfo.get('urls')}
-            </Typography>
-          </div>
+          {sitemapInfo.get('sitemaps') === 0 ? (
+            <div style={{ marginBottom: '15px' }}>
+              <Typography variant="omega">
+                {formatMessage({ id: 'sitemap.Info.SitemapIsPresent.AmountOfURLs', defaultMessage: 'Amount of URLs:' })}
+              </Typography>
+              <Typography variant="omega" fontWeight="bold" style={{ marginLeft: '5px' }}>
+                {sitemapInfo.get('urls')}
+              </Typography>
+            </div>
+          ) : (
+            <div style={{ marginBottom: '15px' }}>
+              <Typography variant="omega">
+                {formatMessage({ id: 'sitemap.Info.SitemapIsPresent.AmountOfSitemaps', defaultMessage: 'Amount of URLs:' })}
+              </Typography>
+              <Typography variant="omega" fontWeight="bold" style={{ marginLeft: '5px' }}>
+                {sitemapInfo.get('sitemaps')}
+              </Typography>
+            </div>
+          )}
           <div style={{ display: 'flex', flexDirection: 'row' }}>
             <Button
               onClick={() => dispatch(generateSitemap(toggleNotification))}

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -55,6 +55,7 @@
   "Info.SitemapIsPresent.Title": "Sitemap XML is present",
   "Info.SitemapIsPresent.LastUpdatedAt": "Last updated at:",
   "Info.SitemapIsPresent.AmountOfURLs": "Amount of URLs:",
+  "Info.SitemapIsPresent.AmountOfSitemaps": "Amount of sitemaps:",
 
   "EditView.ExcludeFromSitemap": "Exclude from Sitemap",
 

--- a/server/config.js
+++ b/server/config.js
@@ -13,6 +13,7 @@ module.exports = {
       'plugin::users-permissions.permission',
       'plugin::users-permissions.role',
     ],
+    limit: 45000,
   },
   validator() {},
 };

--- a/server/controllers/core.js
+++ b/server/controllers/core.js
@@ -74,6 +74,7 @@ module.exports = {
           throw new Error();
         } else {
           sitemapInfo.urls = _.get(result, 'urlset.url.length') || 0;
+          sitemapInfo.sitemaps = _.get(result, 'sitemapindex.sitemap.length') || 0;
         }
       });
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

It automatically creates a paginated sitemap index for sitemaps that exceed the maximum amount of URLs you can add to a single sitemap.

### Why is it needed?

Because large sitemaps (50.000+ URLs) should be split up [according to Google](https://developers.google.com/search/docs/advanced/sitemaps/large-sitemaps).

### Related issue(s)/PR(s)

#66 
