### PR TITLE
fix: Fixed double forward slashes if relation field was empty

### DIFF
--- a/server/services/pattern.js
+++ b/server/services/pattern.js
@@ -93,7 +93,8 @@ const getFieldsFromPattern = (pattern) => {
       }
   });
 
-  pattern = `/${pattern.replace(/\/+/, '')}`; // Make sure we only have on forward slash
+  pattern = pattern.replace(/\/+/g, "/"); // Remove duplicate forward slashes.
+  pattern = pattern.startsWith('/') ? pattern : `/${pattern}`; // Make sure we only have on forward slash.
   return pattern;
 };
 

--- a/server/services/pattern.js
+++ b/server/services/pattern.js
@@ -93,8 +93,7 @@ const getFieldsFromPattern = (pattern) => {
       }
   });
 
-  pattern = pattern.replace(/([^:]\/)\/+/g, "$1"); // Remove duplicate forward slashes.
-  pattern = pattern.startsWith('/') ? pattern : `/${pattern}`; // Add a starting slash.
+  pattern = `/${pattern.replace(/\/+/, '')}`; // Make sure we only have on forward slash
   return pattern;
 };
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

If the relation was empty you would end up with double forward slashes, this caused the url to not be valid in the sitemap.

