### PR TITLE
Change "@fortawesome" to "@fontawesome"

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@strapi/strapi": "^4.0.0"
   },
   "devDependencies": {
-    "@fortawesome/react-fontawesome": "^0.1.16",
+    "@fontawesome/react-fontawesome": "^0.1.16",
     "@strapi/design-system": "^0.0.1-alpha.79",
     "@strapi/helper-plugin": "^4.1.8",
     "@strapi/icons": "^0.0.1-alpha.79",


### PR DESCRIPTION
Under devdependencies in the package.json file... the font awesome package is mispelled and shows "fortawesome". This should be changed to reflect "fontawesome" so that the package can be built correctly and the proper dependency is loaded. 

"@fontawesome/react-fontawesome": "^0.1.16",

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
