### PR TITLE
[FEAT] Allow for queries/filters on collections when generating the sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This is a fork of the work done by the original author. This fork includes an additional feature allowing you to add a conditional to any url bundle. For example you may have a published draft of an entry that is temporarily disabled with a flag, is not available in a certain locale, or maybe you don't want a search engine to index a page without any proper SEO content. 
+
 <div align="center">
 <h1>Strapi sitemap plugin</h1>
 	

--- a/admin/src/components/ModalForm/Collection/index.js
+++ b/admin/src/components/ModalForm/Collection/index.js
@@ -14,6 +14,9 @@ import {
   Box,
   Stack,
   Checkbox,
+  Typography,
+  Flex,
+  Button
 } from '@strapi/design-system';
 
 import SelectContentTypes from '../../SelectContentTypes';
@@ -21,11 +24,13 @@ import SelectContentTypes from '../../SelectContentTypes';
 import form from '../mapper';
 import SelectLanguage from '../../SelectLanguage';
 import useActiveElement from '../../../helpers/useActiveElement';
+import SelectConditional from '../../SelectConditional';
 
 const CollectionForm = (props) => {
   const { formatMessage } = useIntl();
   const activeElement = useActiveElement();
   const [showPopover, setShowPopover] = useState(false);
+  const [conditionCount, setConditionCount] = useState(0);
   const patternRef = useRef();
 
   const {
@@ -60,6 +65,15 @@ const CollectionForm = (props) => {
     }
   }, [modifiedState.getIn([uid, 'languages', langcode, 'pattern'], ''), activeElement]);
 
+  useEffect(() => {
+    // get the initial condition count
+    let count = 0;
+    while (modifiedState.getIn([uid, 'languages', langcode, `condition${count}`], '') !== '') {
+      count++;
+    }
+    setConditionCount(count);
+  }, [uid, langcode]);
+
   const patternHint = () => {
     const base = formatMessage({ id: 'sitemap.Settings.Field.Pattern.DescriptionPart1', defaultMessage: 'Create a dynamic URL pattern' });
     let suffix = '';
@@ -79,6 +93,13 @@ const CollectionForm = (props) => {
     return base + suffix;
   };
 
+  const handleRemoveCondition = () => {
+    onChange(uid, langcode, `condition${conditionCount - 1}`, '')
+    onChange(uid, langcode, `conditionOperator${conditionCount - 1}`, '')
+    onChange(uid, langcode, `conditionValue${conditionCount - 1}`, '')
+    setConditionCount(conditionCount - 1)
+  };
+
   const HoverBox = styled(Box)`
     cursor: pointer;
     &:hover:not([aria-disabled='true']) {
@@ -87,7 +108,7 @@ const CollectionForm = (props) => {
   `;
 
   return (
-    <form style={{ borderTop: '1px solid #f5f5f6', paddingTop: 30 }}>
+    <form style={{ paddingTop: 30 }}>
       <Grid gap={6}>
         <GridItem col={6} s={12}>
           <Grid gap={4}>
@@ -183,6 +204,62 @@ const CollectionForm = (props) => {
           </Grid>
         </GridItem>
       </Grid>
+      {conditionCount === 0
+        ? <Flex direction={"column"} alignItems={"stretch"} style={{ marginTop: '3rem' }}>
+          <Flex direction={"row"} justifyContent={"space-between"}>
+            <Flex direction={"column"} justifyContent={"center"} alignItems={"flex-start"}>
+              <Typography variant="pi" fontWeight="bold">
+                {formatMessage({ id: 'sitemap.Settings.Field.Condition.Label', defaultMessage: 'Conditional Filtering' })}
+              </Typography>
+              <Typography>
+                {formatMessage({ id: 'sitemap.Settings.Field.Condition.Description', defaultMessage: 'Only include URLs that match the following condition.' })}
+              </Typography>
+            </Flex>
+            <Flex direction={"row"} alignItems={"center"} gap={2}>
+              <Button onClick={() => setConditionCount(conditionCount + 1)}>
+                {formatMessage({ id: 'sitemap.Settings.Field.Condition.Add', defaultMessage: 'Add' })}
+              </Button>
+              <Button variant={"secondary"} onClick={() => handleRemoveCondition()}>
+                {formatMessage({ id: 'sitemap.Settings.Field.Condition.Remove', defaultMessage: 'Remove' })}
+              </Button>
+            </Flex>
+          </Flex>
+        </Flex>
+        : <Flex direction={"column"} alignItems={"stretch"} style={{ marginTop: '3rem' }}>
+          <Flex direction={"row"} justifyContent={"space-between"} style={{ marginBottom: '2rem' }}>
+            <Flex direction={"column"} justifyContent={"center"} alignItems={"flex-start"}>
+              <Typography variant="pi" fontWeight="bold">
+                {formatMessage({ id: 'sitemap.Settings.Field.Condition.Label', defaultMessage: 'Conditional Filtering' })}
+              </Typography>
+              <Typography>
+                {formatMessage({ id: 'sitemap.Settings.Field.Condition.Description', defaultMessage: 'Only include URLs that match the following conditions.' })}
+              </Typography>
+            </Flex>
+            <Flex direction={"row"} alignItems={"center"} gap={2}>
+              <Button onClick={() => setConditionCount(conditionCount + 1)}>
+                {formatMessage({ id: 'sitemap.Settings.Field.Condition.Add', defaultMessage: 'Add' })}
+              </Button>
+              <Button variant={"secondary"} onClick={() => handleRemoveCondition()}>
+                {formatMessage({ id: 'sitemap.Settings.Field.Condition.Remove', defaultMessage: 'Remove' })}
+              </Button>
+            </Flex>
+          </Flex>
+          {Array.from(Array(conditionCount).keys()).map((i) => (
+            <Grid gap={4} style={{ marginBottom: "1rem" }}>
+              <SelectConditional
+                disabled={!uid || (contentTypes[uid].locales && !langcode)}
+                contentType={contentTypes[uid]}
+                onConditionChange={(value) => onChange(uid, langcode, `condition${i}`, value)}
+                onOperatorChange={(value) => onChange(uid, langcode, `conditionOperator${i}`, value)}
+                onValueChange={(value) => onChange(uid, langcode, `conditionValue${i}`, value)}
+                condition={modifiedState.getIn([uid, 'languages', langcode, `condition${i}`], '')}
+                conditionOperator={modifiedState.getIn([uid, 'languages', langcode, `conditionOperator${i}`], '')}
+                conditionValue={modifiedState.getIn([uid, 'languages', langcode, `conditionValue${i}`], '')}
+              />
+            </Grid>))
+          }
+        </Flex>
+      }
     </form>
   );
 };

--- a/admin/src/components/SelectConditional/index.js
+++ b/admin/src/components/SelectConditional/index.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Select, Option, TextInput, GridItem } from '@strapi/design-system';
+import { useIntl } from 'react-intl';
+
+const operators = [
+  '$not',
+  '$eq',
+  '$eqi',
+  '$ne',
+  '$in',
+  '$notIn',
+  '$lt',
+  '$lte',
+  '$gt',
+  '$gte',
+  '$between',
+  '$contains',
+  '$notContains',
+  '$containsi',
+  '$notContainsi',
+  '$startsWith',
+  '$endsWith',
+  '$null',
+  '$notNull'
+]
+
+const SelectConditional = (props) => {
+  const { formatMessage } = useIntl();
+
+  const {
+    contentType,
+    disabled,
+    onConditionChange,
+    onOperatorChange,
+    onValueChange,
+    condition,
+    conditionOperator,
+    conditionValue
+  } = props;
+
+  return (
+    <>
+      <GridItem col={4}>
+        <Select
+          name="select"
+          label={formatMessage({ id: 'sitemap.Settings.Field.SelectConditional.Label', defaultMessage: 'Attribute' })}
+          hint={formatMessage({ id: 'sitemap.Settings.Field.SelectConditional.Description', defaultMessage: 'Select an attribute' })}
+          disabled={disabled}
+          onChange={(condition) => onConditionChange(condition)}
+          value={condition}
+        >
+          {contentType && contentType.attributes.map((attribute) => {
+            return <Option value={attribute} key={attribute}>{attribute}</Option>;
+          })}
+        </Select>
+      </GridItem>
+      <GridItem col={2}>
+        <Select
+          name="select"
+          label={formatMessage({ id: 'sitemap.Settings.Field.SelectOperator.Label', defaultMessage: 'Operator' })}
+          hint={formatMessage({ id: 'sitemap.Settings.Field.SelectOperator.Description', defaultMessage: 'Select an operator' })}
+          disabled={disabled}
+          onChange={(operator) => onOperatorChange(operator)}
+          value={conditionOperator}
+        >
+          {operators.map((operator) => {
+            return <Option value={operator} key={operator}>{operator}</Option>;
+          })}
+        </Select>
+      </GridItem>
+      <GridItem col={6}>
+        <TextInput
+          disabled={disabled}
+          label={formatMessage({ id: 'sitemap.Settings.Field.SelectConditionValue.Label', defaultMessage: 'Value' })}
+          name="conditionValue"
+          hint={formatMessage({ id: 'sitemap.Settings.Field.SelectConditionValue.Description', defaultMessage: '"Text", true, 2, etc' })}
+          onChange={e => onValueChange(e.target.value)}
+          value={conditionValue}
+        />
+      </GridItem>
+    </>
+  );
+};
+
+export default SelectConditional;

--- a/server/controllers/core.js
+++ b/server/controllers/core.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const { values } = require('lodash');
 const _ = require('lodash');
 const xml2js = require('xml2js');
 
@@ -36,6 +37,14 @@ module.exports = {
       if (strapi.config.get('plugin.sitemap.excludedTypes').includes(contentType.uid)) return;
       contentTypes[contentType.uid] = {
         displayName: contentType.globalId,
+        attributes: Object.keys(contentType.attributes).filter((key) => {
+          if (key === 'id' || key === 'created_at' || key === 'updated_at') return false;
+          if (contentType.attributes[key].type === 'component') return false;
+          if (contentType.attributes[key].type === 'dynamiczone') return false;
+          if (contentType.attributes[key].type === 'relation') return false;
+          if (contentType.attributes[key].private === true) return false;
+          return true;
+        }) ?? []
       };
 
       if (strapi.plugin('i18n') && _.get(contentType, 'pluginOptions.i18n.localized')) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

This implements conditions into the collections queries. 

Below is a SS of the UI change.

![image](https://user-images.githubusercontent.com/995633/222046057-33cb0899-2031-47f7-830b-5930a89609c6.png)

### Why is it needed?

The general idea here is to make the sitemaps more flexible. In my case, I wanted to filter out anything that was removed from the website when an entry was marked as deleted (but not unpublished so we can retain data where necessary; ie invoicing). 

### How to test it?

Nothing major was added so you should be able to run this as you normally would

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request

I think this only impacts the below issue but there may be some others.

#99 
