### PR TITLE
Update vulnerable xml2js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "redux-immutable": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "sitemap": "^7.1.0",
-    "xml2js": "^0.4.23"
+    "xml2js": "^0.5.0"
   },
   "author": {
     "name": "Boaz Poolman",


### PR DESCRIPTION
### What does it do?

Update xml2js to a version that fixed CVE-2023-0842

### Why is it needed?

CVE-2023-0842