### PR TITLE
Caching

### DIFF
--- a/server/content-types/index.js
+++ b/server/content-types/index.js
@@ -1,7 +1,11 @@
 const sitemapSchema = require('./sitemap/schema.json');
+const sitemapCacheSchema = require('./sitemap_cache/schema.json');
 
 module.exports = {
   sitemap: {
     schema: sitemapSchema,
+  },
+  'sitemap-cache': {
+    schema: sitemapCacheSchema,
   },
 };

--- a/server/content-types/sitemap_cache/schema.json
+++ b/server/content-types/sitemap_cache/schema.json
@@ -1,0 +1,31 @@
+{
+  "kind": "collectionType",
+  "collectionName": "sitemap_cache",
+  "info": {
+    "singularName": "sitemap-cache",
+    "pluralName": "sitemap-caches",
+    "displayName": "sitemap-cache"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {
+    "content-manager": {
+      "visible": false
+    },
+    "content-type-builder": {
+      "visible": false
+    }
+  },
+  "attributes": {
+    "sitemap_json": {
+      "type": "json",
+      "required": true
+    },
+    "name": {
+      "type": "string",
+      "default": "default",
+      "required": true
+    }
+  }
+}

--- a/server/services/core.js
+++ b/server/services/core.js
@@ -104,9 +104,13 @@ const getSitemapPageData = async (page, contentType) => {
 /**
  * Get array of sitemap entries based on the plugins configurations.
  *
+ * @param {string} type - Query only entities of this type.
+ * @param {array} ids - Query only these ids.
+ * @param {bool} excludeDrafts - Whether to exclude drafts.
+ *
  * @returns {object} The cache and regular entries.
  */
-const createSitemapEntries = async (type, id) => {
+const createSitemapEntries = async (type, ids) => {
   const config = await getService('settings').getConfig();
   const sitemapEntries = [];
   const cacheEntries = {};
@@ -120,7 +124,7 @@ const createSitemapEntries = async (type, id) => {
     cacheEntries[contentType] = {};
 
     // Query all the pages
-    const pages = await getService('query').getPages(config, contentType, id);
+    const pages = await getService('query').getPages(config, contentType, ids);
 
     // Add formatted sitemap page data to the array.
     await Promise.all(pages.map(async (page) => {
@@ -226,20 +230,20 @@ const saveSitemap = async (filename, sitemap) => {
  * The main sitemap generation service.
  *
  * @param {array} cache - The cached JSON
- * @param {array} contentType - Content type to refresh
- * @param {array} id - ID to refresh
+ * @param {string} contentType - Content type to refresh
+ * @param {array} ids - IDs to refresh
  *
  * @returns {void}
  */
-const createSitemap = async (cache, contentType, id) => {
+const createSitemap = async (cache, contentType, ids) => {
   try {
     const {
       sitemapEntries,
       cacheEntries,
-    } = await createSitemapEntries(contentType, id);
+    } = await createSitemapEntries(contentType, ids);
 
     // Format cache to regular entries
-    const formattedCache = formatCache(cache, contentType, id);
+    const formattedCache = formatCache(cache, contentType, ids);
 
     const allEntries = [
       ...sitemapEntries,

--- a/server/services/core.js
+++ b/server/services/core.js
@@ -7,7 +7,7 @@
 const { getConfigUrls } = require('@strapi/utils/lib');
 const { SitemapStream, streamToPromise, SitemapAndIndexStream } = require('sitemap');
 const { isEmpty } = require('lodash');
-const { logMessage, getService, formatCache } = require('../utils');
+const { logMessage, getService, formatCache, mergeCache } = require('../utils');
 
 /**
  * Get a formatted array of different language URLs of a single page.
@@ -261,8 +261,7 @@ const createSitemap = async (cache, contentType, id) => {
     if (!cache) {
       await getService('query').createSitemapCache(cacheEntries, 'default');
     } else {
-      // TODO: Better object merging.
-      const newCache = Object.assign(cache, cacheEntries);
+      const newCache = mergeCache(cache, cacheEntries);
       await getService('query').updateSitemapCache(newCache, 'default');
     }
 

--- a/server/services/lifecycle.js
+++ b/server/services/lifecycle.js
@@ -16,27 +16,69 @@ const subscribeLifecycleMethods = async (modelName) => {
       models: [modelName],
 
       async afterCreate(event) {
-        await sitemapService.createSitemap();
+        const cache = await getService('query').getSitemapCache('default');
+        const { id } = event.result;
+
+        if (cache) {
+          await sitemapService.createSitemap(cache.sitemap_json, modelName, id);
+        } else {
+          await sitemapService.createSitemap();
+        }
       },
 
       async afterCreateMany(event) {
-        await sitemapService.createSitemap();
+        const cache = await getService('query').getSitemapCache('default');
+        const { id } = event.result;
+
+        if (cache) {
+          await sitemapService.createSitemap(cache.sitemap_json, modelName, id);
+        } else {
+          await sitemapService.createSitemap();
+        }
       },
 
       async afterUpdate(event) {
-        await sitemapService.createSitemap();
+        const cache = await getService('query').getSitemapCache('default');
+        const { id } = event.result;
+
+        if (cache) {
+          await sitemapService.createSitemap(cache.sitemap_json, modelName, id);
+        } else {
+          await sitemapService.createSitemap();
+        }
       },
 
       async afterUpdateMany(event) {
-        await sitemapService.createSitemap();
+        const cache = await getService('query').getSitemapCache('default');
+        const { id } = event.result;
+
+        if (cache) {
+          await sitemapService.createSitemap(cache.sitemap_json, modelName, id);
+        } else {
+          await sitemapService.createSitemap();
+        }
       },
 
       async afterDelete(event) {
-        await sitemapService.createSitemap();
+        const cache = await getService('query').getSitemapCache('default');
+        const { id } = event.result;
+
+        if (cache) {
+          await sitemapService.createSitemap(cache.sitemap_json, modelName, id);
+        } else {
+          await sitemapService.createSitemap();
+        }
       },
 
       async afterDeleteMany(event) {
-        await sitemapService.createSitemap();
+        const cache = await getService('query').getSitemapCache('default');
+        const { id } = event.result;
+
+        if (cache) {
+          await sitemapService.createSitemap(cache.sitemap_json, modelName, id);
+        } else {
+          await sitemapService.createSitemap();
+        }
       },
     });
   } else {

--- a/server/services/lifecycle.js
+++ b/server/services/lifecycle.js
@@ -18,9 +18,11 @@ const subscribeLifecycleMethods = async (modelName) => {
       async afterCreate(event) {
         const cache = await getService('query').getSitemapCache('default');
         const { id } = event.result;
+        const ids = await getService('query').getLocalizationIds(modelName, id);
+        ids.push(id);
 
         if (cache) {
-          await sitemapService.createSitemap(cache.sitemap_json, modelName, id);
+          await sitemapService.createSitemap(cache.sitemap_json, modelName, ids);
         } else {
           await sitemapService.createSitemap();
         }
@@ -29,9 +31,11 @@ const subscribeLifecycleMethods = async (modelName) => {
       async afterCreateMany(event) {
         const cache = await getService('query').getSitemapCache('default');
         const { id } = event.result;
+        const ids = await getService('query').getLocalizationIds(modelName, id);
+        ids.push(id);
 
         if (cache) {
-          await sitemapService.createSitemap(cache.sitemap_json, modelName, id);
+          await sitemapService.createSitemap(cache.sitemap_json, modelName, ids);
         } else {
           await sitemapService.createSitemap();
         }
@@ -40,9 +44,12 @@ const subscribeLifecycleMethods = async (modelName) => {
       async afterUpdate(event) {
         const cache = await getService('query').getSitemapCache('default');
         const { id } = event.result;
+        const ids = await getService('query').getLocalizationIds(modelName, id);
+        ids.push(id);
+        console.log(ids);
 
         if (cache) {
-          await sitemapService.createSitemap(cache.sitemap_json, modelName, id);
+          await sitemapService.createSitemap(cache.sitemap_json, modelName, ids);
         } else {
           await sitemapService.createSitemap();
         }
@@ -51,9 +58,11 @@ const subscribeLifecycleMethods = async (modelName) => {
       async afterUpdateMany(event) {
         const cache = await getService('query').getSitemapCache('default');
         const { id } = event.result;
+        const ids = await getService('query').getLocalizationIds(modelName, id);
+        ids.push(id);
 
         if (cache) {
-          await sitemapService.createSitemap(cache.sitemap_json, modelName, id);
+          await sitemapService.createSitemap(cache.sitemap_json, modelName, ids);
         } else {
           await sitemapService.createSitemap();
         }
@@ -62,9 +71,11 @@ const subscribeLifecycleMethods = async (modelName) => {
       async afterDelete(event) {
         const cache = await getService('query').getSitemapCache('default');
         const { id } = event.result;
+        const ids = await getService('query').getLocalizationIds(modelName, id);
+        ids.push(id);
 
         if (cache) {
-          await sitemapService.createSitemap(cache.sitemap_json, modelName, id);
+          await sitemapService.createSitemap(cache.sitemap_json, modelName, ids);
         } else {
           await sitemapService.createSitemap();
         }
@@ -73,9 +84,11 @@ const subscribeLifecycleMethods = async (modelName) => {
       async afterDeleteMany(event) {
         const cache = await getService('query').getSitemapCache('default');
         const { id } = event.result;
+        const ids = await getService('query').getLocalizationIds(modelName, id);
+        ids.push(id);
 
         if (cache) {
-          await sitemapService.createSitemap(cache.sitemap_json, modelName, id);
+          await sitemapService.createSitemap(cache.sitemap_json, modelName, ids);
         } else {
           await sitemapService.createSitemap();
         }

--- a/server/services/query.js
+++ b/server/services/query.js
@@ -12,11 +12,12 @@ const { noLimit, getService } = require("../utils");
  *
  * @param {obj} contentType - The content type
  * @param {bool} topLevel - Should include only top level fields
+ * @param {bool} isLocalized - Should include the locale field
  * @param {string} relation - Specify a relation. If you do; the function will only return fields of that relation.
  *
  * @returns {array} The fields.
  */
-const getFieldsFromConfig = (contentType, topLevel = false, relation) => {
+const getFieldsFromConfig = (contentType, topLevel = false, isLocalized = false, relation) => {
   let fields = [];
 
   if (contentType) {
@@ -26,7 +27,10 @@ const getFieldsFromConfig = (contentType, topLevel = false, relation) => {
   }
 
   if (topLevel) {
-    fields.push('locale');
+    if (isLocalized) {
+      fields.push('locale');
+    }
+
     fields.push('updatedAt');
   }
 
@@ -52,7 +56,7 @@ const getRelationsFromConfig = (contentType) => {
       const relations = getService('pattern').getRelationsFromPattern(pattern);
       relations.map((relation) => {
         relationsObject[relation] = {
-          fields: getFieldsFromConfig(contentType, false, relation),
+          fields: getFieldsFromConfig(contentType, false, false, relation),
         };
       });
     });
@@ -66,33 +70,43 @@ const getRelationsFromConfig = (contentType) => {
  *
  * @param {obj} config - The config object
  * @param {obj} contentType - The content type
+ * @param {number} id - A page id
  *
  * @returns {object} The pages.
  */
-const getPages = async (config, contentType) => {
+const getPages = async (config, contentType, id) => {
   const excludeDrafts = config.excludeDrafts && strapi.contentTypes[contentType].options.draftAndPublish;
+  const isLocalized = strapi.contentTypes[contentType].pluginOptions?.i18n?.localized;
 
   const relations = getRelationsFromConfig(config.contentTypes[contentType]);
-  const fields = getFieldsFromConfig(config.contentTypes[contentType], true);
+  const fields = getFieldsFromConfig(config.contentTypes[contentType], true, isLocalized);
+
+  // TODO:
+  // Double check if the filters are working correctly
+  const filters = {
+    $or: [
+      {
+        sitemap_exclude: {
+          $null: true,
+        },
+      },
+      {
+        sitemap_exclude: {
+          $eq: false,
+        },
+      },
+    ],
+    id: id ? {
+      $eq: id,
+    } : {},
+    published_at: excludeDrafts ? {
+      $notNull: true,
+    } : {},
+  };
 
   const pages = await noLimit(strapi, contentType, {
-    where: {
-      $or: [
-        {
-          sitemap_exclude: {
-            $null: true,
-          },
-        },
-        {
-          sitemap_exclude: {
-            $eq: false,
-          },
-        },
-      ],
-      published_at: excludeDrafts ? {
-        $notNull: true,
-      } : {},
-    },
+    where: filters,
+    filters,
     locale: 'all',
     fields,
     populate: {
@@ -123,6 +137,7 @@ const createSitemap = async (sitemapString, name, delta) => {
       name,
       delta,
     },
+    fields: ['id'],
   });
 
   if (sitemap[0]) {
@@ -169,6 +184,7 @@ const deleteSitemap = async (name) => {
     filters: {
       name,
     },
+    fields: ['id'],
   });
 
   await Promise.all(sitemaps.map(async (sm) => {
@@ -176,10 +192,83 @@ const deleteSitemap = async (name) => {
   }));
 };
 
+/**
+ * Create a sitemap_cache in the database
+ *
+ * @param {string} sitemapJson - The sitemap JSON
+ * @param {string} name - The name of the sitemap
+ *
+ * @returns {void}
+ */
+const createSitemapCache = async (sitemapJson, name) => {
+  const sitemap = await strapi.entityService.findMany('plugin::sitemap.sitemap-cache', {
+    filters: {
+      name,
+    },
+    fields: ['id'],
+  });
+
+  if (sitemap[0]) {
+    await strapi.entityService.delete('plugin::sitemap.sitemap-cache', sitemap[0].id);
+  }
+
+  await strapi.entityService.create('plugin::sitemap.sitemap-cache', {
+    data: {
+      sitemap_json: sitemapJson,
+      name,
+    },
+  });
+};
+
+/**
+ * Update a sitemap_cache in the database
+ *
+ * @param {string} sitemapJson - The sitemap JSON
+ * @param {string} name - The name of the sitemap
+ *
+ * @returns {void}
+ */
+const updateSitemapCache = async (sitemapJson, name) => {
+  const sitemap = await strapi.entityService.findMany('plugin::sitemap.sitemap-cache', {
+    filters: {
+      name,
+    },
+    fields: ['id'],
+  });
+
+  if (sitemap[0]) {
+    await strapi.entityService.update('plugin::sitemap.sitemap-cache', sitemap[0].id, {
+      data: {
+        sitemap_json: sitemapJson,
+        name,
+      },
+    });
+  }
+};
+
+/**
+ * Get a sitemap_cache from the database
+ *
+ * @param {string} name - The name of the sitemap
+ *
+ * @returns {void}
+ */
+const getSitemapCache = async (name) => {
+  const sitemap = await strapi.entityService.findMany('plugin::sitemap.sitemap-cache', {
+    filters: {
+      name,
+    },
+  });
+
+  return sitemap[0];
+};
 
 module.exports = () => ({
   getPages,
   createSitemap,
   getSitemap,
   deleteSitemap,
+  createSitemapCache,
+  updateSitemapCache,
+  getSitemapCache,
 });

--- a/server/services/query.js
+++ b/server/services/query.js
@@ -81,32 +81,24 @@ const getPages = async (config, contentType, id) => {
   const relations = getRelationsFromConfig(config.contentTypes[contentType]);
   const fields = getFieldsFromConfig(config.contentTypes[contentType], true, isLocalized);
 
-  // TODO:
-  // Double check if the filters are working correctly
-  const filters = {
-    $or: [
-      {
-        sitemap_exclude: {
-          $null: true,
-        },
-      },
-      {
-        sitemap_exclude: {
-          $eq: false,
-        },
-      },
-    ],
-    id: id ? {
-      $eq: id,
-    } : {},
-    published_at: excludeDrafts ? {
-      $notNull: true,
-    } : {},
-  };
-
   const pages = await noLimit(strapi, contentType, {
-    where: filters,
-    filters,
+    filters: {
+      $or: [
+        {
+          sitemap_exclude: {
+            $null: true,
+          },
+        },
+        {
+          sitemap_exclude: {
+            $eq: false,
+          },
+        },
+      ],
+      id: id ? {
+        $eq: id,
+      } : {},
+    },
     locale: 'all',
     fields,
     populate: {
@@ -117,6 +109,7 @@ const getPages = async (config, contentType, id) => {
       ...relations,
     },
     orderBy: 'id',
+    publicationState: excludeDrafts ? 'live' : 'preview',
   });
 
   return pages;

--- a/server/utils/__tests__/index.test.js
+++ b/server/utils/__tests__/index.test.js
@@ -1,0 +1,101 @@
+
+'use strict';
+
+const {
+  formatCache,
+  mergeCache,
+  logMessage,
+} = require('..');
+
+describe('Caching utilities', () => {
+  describe('Format cache', () => {
+    const cache = {
+      "api::page.page": {
+        1: { url: "/test/page/1" },
+        2: { url: "/test/page/2" },
+        3: { url: "/test/page/3" },
+      },
+      "api::category.category": {
+        1: { url: "/test/category/1" },
+      },
+    };
+
+    test('Should format and invalidate the cache for specific ids of content type', () => {
+      const formattedCache = formatCache(cache, 'api::page.page', [2, 3]);
+      expect(formattedCache).toEqual([
+        { url: "/test/page/1" },
+        { url: "/test/category/1" },
+      ]);
+    });
+
+    test('Should format and invalidate the cache for an entire content type', () => {
+      const formattedCache = formatCache(cache, 'api::page.page');
+      expect(formattedCache).toEqual([
+        { url: "/test/category/1" },
+      ]);
+    });
+  });
+
+  describe('Merge cache', () => {
+    const cache = {
+      "api::page.page": {
+        1: { url: "/test/page/1" },
+        2: { url: "/test/page/2" },
+        3: { url: "/test/page/3" },
+      },
+      "api::category.category": {
+        1: { url: "/test/category/1" },
+      },
+    };
+
+    test('Should merge the cache correctly to add a page', () => {
+      const newCache = {
+        "api::page.page": {
+          4: { url: "/test/page/4" },
+        },
+      };
+
+      const mergedCache = mergeCache(cache, newCache);
+
+      expect(mergedCache).toEqual({
+        "api::page.page": {
+          1: { url: "/test/page/1" },
+          2: { url: "/test/page/2" },
+          3: { url: "/test/page/3" },
+          4: { url: "/test/page/4" },
+        },
+        "api::category.category": {
+          1: { url: "/test/category/1" },
+        },
+      });
+    });
+
+    test('Should merge the cache correctly to remove a page', () => {
+      const newCache = {
+        "api::page.page": {},
+      };
+
+      const mergedCache = mergeCache(cache, newCache);
+
+      expect(mergedCache).toEqual({
+        "api::category.category": {
+          1: { url: "/test/category/1" },
+        },
+        "api::page.page": {
+          1: { url: "/test/page/1" },
+          2: { url: "/test/page/2" },
+          3: { url: "/test/page/3" },
+        },
+      });
+    });
+  });
+});
+
+describe('Generic utilities', () => {
+  describe('Log message formatting', () => {
+    const message = logMessage('An error occurred');
+
+    expect(message).toEqual('[strapi-plugin-sitemap]: An error occurred');
+
+  });
+});

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -12,7 +12,7 @@ const logMessage = (msg = '') => `[strapi-plugin-sitemap]: ${msg}`;
 
 const noLimit = async (strapi, queryString, parameters, limit = 100) => {
   let entries = [];
-  const amountOfEntries = await strapi.query(queryString).count(parameters);
+  const amountOfEntries = await strapi.entityService.count(queryString, parameters);
 
   for (let i = 0; i < (amountOfEntries / limit); i++) {
     /* eslint-disable-next-line */
@@ -24,12 +24,16 @@ const noLimit = async (strapi, queryString, parameters, limit = 100) => {
     entries = [...chunk, ...entries];
   }
 
+  console.log(queryString, amountOfEntries, entries);
+
   return entries;
 };
 
 const formatCache = (cache, contentType, id) => {
   let formattedCache = [];
 
+  // TODO:
+  // Cache invalidation & regeneration should also occur for al its translated counterparts
   if (cache) {
     // Remove the items from the cache that will be refreshed.
     if (contentType && id) {
@@ -51,10 +55,23 @@ const formatCache = (cache, contentType, id) => {
   return formattedCache;
 };
 
+const mergeCache = (oldCache, newCache) => {
+  const mergedCache = [oldCache, newCache].reduce((merged, current) => {
+    Object.entries(current).forEach(([key, value]) => {
+      merged[key] ??= {};
+      merged[key] = { ...merged[key], ...value };
+    });
+    return merged;
+  }, {});
+
+  return mergedCache;
+};
+
 module.exports = {
   getService,
   getCoreStore,
   logMessage,
   noLimit,
   formatCache,
+  mergeCache,
 };

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -33,7 +33,7 @@ const formatCache = (cache, contentType, ids) => {
   if (cache) {
     // Remove the items from the cache that will be refreshed.
     if (contentType && ids) {
-      ids.map((id) => delete cache[contentType][id]);
+      ids.map((id) => delete cache[contentType]?.[id]);
     } else if (contentType) {
       delete cache[contentType];
     }

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -24,20 +24,16 @@ const noLimit = async (strapi, queryString, parameters, limit = 100) => {
     entries = [...chunk, ...entries];
   }
 
-  console.log(queryString, amountOfEntries, entries);
-
   return entries;
 };
 
-const formatCache = (cache, contentType, id) => {
+const formatCache = (cache, contentType, ids) => {
   let formattedCache = [];
 
-  // TODO:
-  // Cache invalidation & regeneration should also occur for al its translated counterparts
   if (cache) {
     // Remove the items from the cache that will be refreshed.
-    if (contentType && id) {
-      delete cache[contentType][id];
+    if (contentType && ids) {
+      ids.map((id) => delete cache[contentType][id]);
     } else if (contentType) {
       delete cache[contentType];
     }

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -54,7 +54,7 @@ const formatCache = (cache, contentType, ids) => {
 const mergeCache = (oldCache, newCache) => {
   const mergedCache = [oldCache, newCache].reduce((merged, current) => {
     Object.entries(current).forEach(([key, value]) => {
-      merged[key] ??= {};
+      if (!merged[key]) merged[key] = {};
       merged[key] = { ...merged[key], ...value };
     });
     return merged;

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -27,9 +27,34 @@ const noLimit = async (strapi, queryString, parameters, limit = 100) => {
   return entries;
 };
 
+const formatCache = (cache, contentType, id) => {
+  let formattedCache = [];
+
+  if (cache) {
+    // Remove the items from the cache that will be refreshed.
+    if (contentType && id) {
+      delete cache[contentType][id];
+    } else if (contentType) {
+      delete cache[contentType];
+    }
+
+    Object.values(cache).map((values) => {
+      if (values) {
+        formattedCache = [
+          ...formattedCache,
+          ...Object.values(values),
+        ];
+      }
+    });
+  }
+
+  return formattedCache;
+};
+
 module.exports = {
   getService,
   getCoreStore,
   logMessage,
   noLimit,
+  formatCache,
 };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

I've implemented a caching layer for sitemaps.
This cache is stored in the sitemap_cache table in the DB.
It stores the JSON representation of a sitemap.

As soon as a page gets edited, it will trigger a rebuild of the sitemap.
Instead of querying all (unedited pages) we will query the cache.
Then we'll query just the edited page and replace the old entry in the cache with the new.
Finally we will rebuild the sitemap XML based on the cache we just updated.

### Why is it needed?

Fix performance issues

### How to test it?

Install PR

### Related issue(s)/PR(s)

#80, #83 
